### PR TITLE
Update stack; Change base image to amazonlinux:1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-20191118-slim
+FROM amazonlinux:2
 
 ARG STACK_VERSION=2.1.3
 ENV \
@@ -7,8 +7,8 @@ ENV \
 
 RUN \
   set -o xtrace && \
-  apt-get update && \
-  apt-get install --assume-yes \
+  yum update -y && \
+  yum install -y \
     gcc \
     git \
     libgmp-dev \
@@ -19,7 +19,6 @@ RUN \
     wget \
     xz-utils \
     zlib1g-dev && \
-  apt-get auto-clean && \
   cd /tmp && \
   wget \
     --output-document stack.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     wget \
     xz-utils \
     zlib1g-dev && \
+  apt-get auto-clean && \
   cd /tmp && \
   wget \
     --output-document stack.tgz \
@@ -31,6 +32,6 @@ RUN \
     --wildcards '*/stack' && \
   rm stack.tgz && \
   mv stack /usr/local/bin/ && \
+  stack upgrade --git && \
+  rm -r /stack-root && \
   stack --version
-
-RUN stack upgrade --git

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
     netbase \
     wget \
     xz-utils \
+    tar \
     zlib1g-dev && \
   cd /tmp && \
   wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG STACK_VERSION=2.1.3
+ARG STACK_VERSION=2.3.0.1
 ENV \
   PATH=/root/.local/bin:$PATH \
   STACK_ROOT=/stack-root
@@ -38,6 +38,4 @@ RUN \
     --wildcards '*/stack' && \
   rm stack.tgz && \
   mv stack /usr/local/bin/ && \
-  stack upgrade --git && \
-  rm -r /stack-root && \
   stack --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-20190708-slim
+FROM debian:stretch-20191118-slim
 
 ARG STACK_VERSION=2.1.3
 ENV \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ RUN \
   rm stack.tgz && \
   mv stack /usr/local/bin/ && \
   stack --version
+
+RUN stack upgrade --git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM amazonlinux:2018.03.0.20180827
 
 ARG STACK_VERSION=2.3.0.1
 ENV \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,17 @@ RUN \
     gmp-devel \
     gzip \
     make \
+    nc \
     ncurses-devel \
+    netcat-openbsd \
     perl \
+    postgresql-client-9.6 \
     postgresql-devel \
+    procps \
     tar \
+    wget \
     xz \
     zip \
-    wget \
     zlib-devel && \
   cd /tmp && \
   wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,17 @@ RUN \
   yum install -y \
     gcc \
     git \
-    libgmp-dev \
-    libpq-dev \
-    libtinfo-dev \
+    gmp-devel \
+    gzip \
     make \
-    netbase \
-    wget \
-    xz-utils \
+    ncurses-devel \
+    perl \
+    postgresql-devel \
     tar \
-    zlib1g-dev && \
+    xz \
+    zip \
+    wget \
+    zlib-devel && \
   cd /tmp && \
   wget \
     --output-document stack.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     git \
     gmp-devel \
     gzip \
+    libc6 \
     make \
     nc \
     ncurses-devel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN \
     git \
     gmp-devel \
     gzip \
-    libc6 \
     make \
     nc \
     ncurses-devel \


### PR DESCRIPTION
Story Details: https://app.clubhouse.io/itprotv/story/39961

Changes:
- Use stack version 2.3.0.1-rc
- Base is at amazonlinux:1 since we need to be on this image to run lambdas correctly
- Change includes commonly used dependencies like postgres client and misc sh tools