### PR TITLE
Upgrade Stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ncurses-devel \
     netcat-openbsd \
     perl \
-    postgresql-client-9.11 \
+    postgresql-client-11 \
     postgresql-devel \
     procps \
     tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM amazonlinux:2018.03.0.20180827
+FROM amazonlinux:2
 
-ARG STACK_VERSION=2.3.1
+ARG STACK_VERSION=2.3.3
 ENV \
   PATH=/root/.local/bin:$PATH \
   STACK_ROOT=/stack-root
@@ -18,7 +18,7 @@ RUN \
     ncurses-devel \
     netcat-openbsd \
     perl \
-    postgresql-client-9.6 \
+    postgresql-client-9.11 \
     postgresql-devel \
     procps \
     tar \
@@ -39,4 +39,6 @@ RUN \
     --wildcards '*/stack' && \
   rm stack.tgz && \
   mv stack /usr/local/bin/ && \
+  stack upgrade --git && \
+  rm -r /stack-root && \
   stack --version


### PR DESCRIPTION
Story Details: https://app.clubhouse.io/itprotv/story/46974

Current Changes (In Draft):
- Upgrade to `amazonlinux2`
  - This will require terraform change to support latest lambda runtime `provided.al2`
- Upgrade to `postgresql-client11`
- Download stack 2.3.3 and upgrade to latest HEAD which at the time of writing is: https://github.com/commercialhaskell/stack/commit/1b1bed5b84b3aed76cf27b02cadd46d09efc611f

_Note: Only merge after stack upgrades to latest version including latest HEAD changes, specifically: https://github.com/commercialhaskell/stack/pull/5351_