### PR TITLE
Stack 2.5.0.1 release candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM amazonlinux:2.0.20200722.0
 
 ARG STACK_VERSION=2.5.0.1
+ARG ITPROTV_ROOT=/home/itprotv
 
 ENV LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
-  ITPROTV_ROOT=/home/itprotv \
   STACK_ROOT=$ITPROTV_ROOT/.stack
 
 RUN yum update -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ncurses-devel \
     netcat-openbsd \
     perl \
-    postgresql-client-9.6 \
+    postgresql-client-11 \
     postgresql-devel \
     procps \
     tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM amazonlinux:2.0.20200722.0
 
 ARG STACK_VERSION=2.5.0.1
-ARG ITPROTV_ROOT=/home/itprotv
 
 ENV LANG=C.UTF-8 \
-  LC_ALL=C.UTF-8 \
-  STACK_ROOT=$ITPROTV_ROOT/.stack
+  LC_ALL=C.UTF-8
 
 RUN yum update -y \
   && yum install -y \
@@ -29,10 +27,10 @@ RUN yum update -y \
     zlib-devel \
   && yum clean all \
   && rm -rf /var/cache/yum \
-  && mkdir -p $ITPROTV_ROOT/tmp \
-  && cd $ITPROTV_ROOT/tmp \
+  && mkdir -p /tmp/stack \
+  && cd /tmp/stack \
   && wget --output-document stack.tgz --no-verbose "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" \
   && tar --extract --file stack.tgz --strip-components 1 --wildcards '*/stack' \
   && rm stack.tgz \
   && mv stack /usr/local/bin/ \
-  && cd .. && rm -r $ITPROTV_ROOT/tmp
+  && cd .. && rm -r /tmp/stack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM amazonlinux:2.0.20200722.0
 
 ARG STACK_VERSION=2.5.0.1
-ENV \
-  PATH=/root/.local/bin:$PATH \
-  STACK_ROOT=/stack-root
 
-RUN \
-  set -o xtrace && \
-  yum update -y && \
-  yum install -y \
+ENV LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  ITPROTV_ROOT=/home/itprotv \
+  STACK_ROOT=$ITPROTV_ROOT/.stack
+
+RUN yum update -y \
+  && yum install -y \
     gcc \
     git \
     gmp-devel \
@@ -26,17 +26,15 @@ RUN \
     xz \
     xz-devel \
     zip \
-    zlib-devel && \
-  cd /tmp && \
-  wget \
-    --output-document stack.tgz \
-    --no-verbose \
-    "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" && \
-  tar \
-    --extract \
-    --file stack.tgz \
-    --strip-components 1 \
-    --wildcards '*/stack' && \
-  rm stack.tgz && \
-  mv stack /usr/local/bin/ && \
-  stack --version
+    zlib-devel \
+  && yum clean all \
+  && rm -rf /var/cache/yum \
+  && mkdir -p $ITPROTV_ROOT/tmp \
+  && cd $ITPROTV_ROOT/tmp \
+  && wget --output-document stack.tgz --no-verbose "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" \
+  && tar --extract --file stack.tgz --strip-components 1 --wildcards '*/stack' \
+  && rm stack.tgz \
+  && mv stack /usr/local/bin/ \
+  && cd .. && rm -r $ITPROTV_ROOT/tmp
+
+ENTRYPOINT [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,3 @@ RUN yum update -y \
   && rm stack.tgz \
   && mv stack /usr/local/bin/ \
   && cd .. && rm -r $ITPROTV_ROOT/tmp
-
-ENTRYPOINT [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2018.03.0.20180827
+FROM amazonlinux:2.0.20200722.0
 
 ARG STACK_VERSION=2.3.1
 ENV \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2.0.20200722.0
 
-ARG STACK_VERSION=2.3.1
+ARG STACK_VERSION=2.5.0.1
 ENV \
   PATH=/root/.local/bin:$PATH \
   STACK_ROOT=/stack-root


### PR DESCRIPTION
Alternative to #3. 

See https://github.com/commercialhaskell/stack/releases/tag/v2.5.0.1. 

Also https://hub.docker.com/layers/amazonlinux/library/amazonlinux/2.0.20200722.0/images/sha256-1481659e18042055e174f9f5e61998bf7ab57f8c9432f3c9412a56d116cc0c68?context=explore. 