### PR TITLE
Update to 2.5.0.1 & Pre build dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     ncurses-devel \
     netcat-openbsd \
     perl \
-    postgresql-client-9.11 \
+    postgresql-client-11 \
     postgresql-devel \
     procps \
     tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM amazonlinux:2
+FROM amazonlinux:2.0.20200722.0
 
-ARG STACK_VERSION=2.3.3
-ENV \
-  PATH=/root/.local/bin:$PATH \
-  STACK_ROOT=/stack-root
+# GHC version should match the LTS version, otherwise the path will not have the correct ghc version
+ARG GHC_VERSION=8.8.4
+ARG LTS_VERSION=lts-16.15
+ARG STACK_VERSION=2.5.0.1
 
-RUN \
-  set -o xtrace && \
-  yum update -y && \
-  yum install -y \
+ARG ITPROTV_ROOT=/home/itprotv
+ARG STACK_ROOT=$ITPROTV_ROOT/.stack
+
+ENV LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  PATH=$STACK_ROOT/programs/x86_64-linux/ghc-$GHC_VERSION/bin:$PATH \
+  STACK_ROOT=$STACK_ROOT
+
+RUN yum update -y \
+  && yum install -y \
     gcc \
     git \
     gmp-devel \
@@ -26,19 +32,201 @@ RUN \
     xz \
     xz-devel \
     zip \
-    zlib-devel && \
-  cd /tmp && \
-  wget \
-    --output-document stack.tgz \
-    --no-verbose \
-    "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" && \
-  tar \
-    --extract \
-    --file stack.tgz \
-    --strip-components 1 \
-    --wildcards '*/stack' && \
-  rm stack.tgz && \
-  mv stack /usr/local/bin/ && \
-  stack upgrade --git && \
-  rm -r /stack-root && \
-  stack --version
+    zlib-devel \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+RUN mkdir -p $STACK_ROOT \
+  && echo "system-ghc: true" >$STACK_ROOT/config.yaml \
+  && echo "recommend-stack-upgrade: false" >>$STACK_ROOT/config.yaml \
+  && echo "allow-different-user: true" >>$STACK_ROOT/config.yaml \
+  && echo "local-bin-path: /usr/bin" >>$STACK_ROOT/config.yaml \
+  && mkdir -p $ITPROTV_ROOT/tmp \
+  && cd $ITPROTV_ROOT/tmp \
+  && wget --output-document stack.tgz --no-verbose "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" \
+  && tar --extract --file stack.tgz --strip-components 1 --wildcards '*/stack' \
+  && rm stack.tgz \
+  && mv stack /usr/local/bin/ \
+  && cd .. && rm -r $ITPROTV_ROOT/tmp
+
+# Install ghc/lts
+RUN stack setup --resolver=$LTS_VERSION
+
+# Cache hackage index
+RUN stack update
+
+# The cached dependencies are done in a hopefully hierarchichal way:
+# - Common haskell libraries that may not necessarily be used by our application are installed first
+# - The dependencies that will almost never change or require hacking are installed first
+# - Some known dependencies that take a long time will be built separately to avoid recompiling a
+#   lot of stuff.
+# - The custom stack yaml is added after the common libraries are install so that modifying it does
+#   not rebuild the common libraries. Beware that if the stack.yaml overrides one of these libraries
+#   the cache will duplicate them and some space will be lost.
+# - The application libraries will be installed in one gulp. Changing one will cause a full rebuild
+#   but there's no easy way to cache this correctly otherwise.
+# - The commonly used binaries for development are installed last (so we can add new tools without
+#   rebuilding everything)
+
+# Common Haskell libraries
+RUN stack build \
+      alex \
+      base \
+      fsnotify \
+      happy \
+      hscolour \
+      say
+
+# Common Application dependencies
+RUN stack build \
+      async \
+      bytestring \
+      directory \
+      exceptions \
+      filepath \
+      network \
+      network-uri \
+      process \
+      random \
+      scientific \
+      template-haskell \
+      text \
+      time \
+      uuid \
+      vector
+
+# Known slow dependencies
+RUN stack build \
+      ghc-lib-parser \
+      haskell-src-exts \
+      tls
+
+# Copy stack.yaml with overriden packages and extra-deps
+COPY stack.yaml $ITPROTV_ROOT/stack.yaml.partial
+
+# Clone extra dependencies
+RUN cat $ITPROTV_ROOT/stack.yaml.partial >> $ITPROTV_ROOT/.stack/global-project/stack.yaml \
+  && rm $ITPROTV_ROOT/stack.yaml.partial \
+  && stack update
+
+# Prebuild application dependencies. You may see precache contain these dependencies, that's fine.
+RUN stack build \
+      aeson \
+      aeson-pretty \
+      aeson-qq \
+      AesonBson \
+      amazonka \
+      amazonka-cloudwatch \
+      amazonka-cloudwatch-events \
+      amazonka-core \
+      amazonka-lambda \
+      amazonka-s3 \
+      amazonka-sns \
+      amazonka-sqs \
+      amazonka-sts \
+      async \
+      attoparsec \
+      autoexporter \
+      base-noprelude \
+      base64-bytestring \
+      bcrypt \
+      brittany \
+      bson \
+      bytestring \
+      case-insensitive \
+      cassava \
+      conduit \
+      conduit-combinators \
+      containers \
+      convertible \
+      cryptonite \
+      csv-conduit \
+      deepseq \
+      directory \
+      dlist \
+      either \
+      esqueleto \
+      exceptions \
+      filepath \
+      happstack-server \
+      hashable \
+      haskell-src-exts \
+      HDBC \
+      HDBC-postgresql \
+      hedis \
+      hlint \
+      hpack \
+      HPDF \
+      hslogger \
+      hspec \
+      hspec-core \
+      hspec-expectations-pretty-diff \
+      http-api-data \
+      http-client \
+      http-client-tls \
+      http-conduit \
+      http-media \
+      http-types \
+      insert-ordered-containers \
+      JuicyPixels \
+      JuicyPixels-extra \
+      jwt \
+      lens \
+      lens-aeson \
+      memory \
+      monad-control \
+      monad-logger \
+      mongoDB \
+      mono-traversable \
+      mtl \
+      neat-interpolation \
+      network \
+      network-uri \
+      orville \
+      parsec \
+      persistent \
+      persistent-mongoDB \
+      persistent-postgresql \
+      persistent-template \
+      pretty-simple \
+      process \
+      prolude \
+      QuickCheck \
+      quickcheck-instances \
+      random \
+      resource-pool \
+      resourcet \
+      safe-exceptions \
+      safe-money \
+      scientific \
+      servant \
+      servant-server \
+      servant-swagger \
+      servant-swagger-ui \
+      silently \
+      stm \
+      stringsearch \
+      swagger2 \
+      template-haskell \
+      text \
+      time \
+      transformers \
+      transformers-base \
+      unliftio-core \
+      unordered-containers \
+      uuid \
+      vector \
+      wai \
+      warp \
+      xml-conduit \
+      xml-conduit-writer \
+      xml-lens \
+      xml-types
+
+# Commonly used dev tools
+RUN stack install \
+      brittany \
+      ghcid \
+      hlint \
+      hoogle \
+      hasktags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM amazonlinux:2018.03.0.20180827
+FROM amazonlinux:2
 
-ARG STACK_VERSION=2.3.1
+ARG STACK_VERSION=2.3.3
 ENV \
   PATH=/root/.local/bin:$PATH \
   STACK_ROOT=/stack-root
@@ -18,7 +18,7 @@ RUN \
     ncurses-devel \
     netcat-openbsd \
     perl \
-    postgresql-client-9.6 \
+    postgresql-client-9.11 \
     postgresql-devel \
     procps \
     tar \
@@ -39,4 +39,6 @@ RUN \
     --wildcards '*/stack' && \
   rm stack.tgz && \
   mv stack /usr/local/bin/ && \
+  stack upgrade --git && \
+  rm -r /stack-root && \
   stack --version

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,49 @@
+extra-deps:
+  - AesonBson-0.4.0
+  - happstack-server-7.6.0
+  - HDBC-postgresql-2.3.2.7
+  - HPDF-1.5.1
+  - json-0.10
+  - prolude-0.0.0.0
+  - servant-0.18
+  - servant-server-0.18
+
+  # We have our own custom orville package that we forked from flipstone:
+  # https://github.com/flipstone/orville
+  - git: https://github.com/EdutainmentLIVE/orville
+    commit: 8a2432891e96a547777b67a67135e235a1dce80c
+
+  # These packages require patches that aren't yet available on Hackage. We're
+  # required to pull them from GitHub instead. If you add a package here, be
+  # sure to include a link to an upstream pull request. Once the pull request
+  # is merged and released to Hackage, we can stop using the GitHub source.
+
+  # <https://github.com/hdbc/convertible/pull/15>
+  - git: https://github.com/codygman/convertible
+    commit: 9e4849e143458aa3175e71bc2a8a29502272eb88
+
+  # Brittany for patterns <https://github.com/lspitzner/brittany/issues/199>
+  - git: https://github.com/lspitzner/brittany
+    commit: 7d68b1cc3809e2921756c3a1bf67a83e82c21b0a
+
+  # <https://github.com/yesodweb/persistent/pull/1129>
+  - git: https://github.com/codygman/persistent
+    commit: 71de35824f3592efb6cdb6cfd3fe29bb119008c0
+    subdirs:
+      - persistent-mongoDB
+
+  # Allows passing empty symbol to get automatic capture docs
+  # <https://github.com/haskell-servant/servant-swagger/pull/125>
+  - git: https://github.com/haskell-servant/servant-swagger
+    commit: 2c0bf4759a96e848130f6a16fb45d6525bf06522
+
+  # <https://github.com/haskell-servant/servant-swagger-ui/pull/78>
+  - git: https://github.com/aschmois/servant-swagger-ui
+    commit: 8c697a4ddb4d128e2c1fb5795ee1ee1892ff250a
+    subdirs:
+      - servant-swagger-ui-core
+      - servant-swagger-ui
+
+  # <https://github.com/haskell-servant/servant-blaze/pull/19>
+  - git: https://github.com/aschmois/servant-blaze
+    commit: b0d5d16e7bce3c22ea3ebce8ed29f28fd1e4a64a


### PR DESCRIPTION
Changes:
- Uses stack 2.5.0.1
- Prebuilds our dependencies
- Currently tries to be smart with how they're cached, might collapse into one command if the size turns out to be way bigger.