### PR TITLE
Use ubuntu as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM amazonlinux:2.0.20200722.0
 
 ARG STACK_VERSION=2.5.1
-ARG USER=haskell
 
 ENV LANG=C.UTF-8
-ENV PATH="/home/$USER/.local/bin:$PATH"
 
 RUN yum update -y \
   && amazon-linux-extras install postgresql11 \
@@ -33,8 +31,4 @@ RUN yum update -y \
   && tar --extract --file stack.tgz --strip-components 1 --wildcards '*/stack' \
   && mv stack /usr/local/bin/ \
   && cd - \
-  && rm -r /tmp/stack \
-  && useradd --create-home "$USER" \
-  && echo "$USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-USER "$USER"
+  && rm -r /tmp/stack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,35 @@
-FROM amazonlinux:2.0.20200722.0
+FROM ubuntu:focal-20210401
 
+ARG DEBIAN_FRONTEND=noninteractive
 ARG STACK_VERSION=2.5.1
 
 ENV LANG=C.UTF-8
 
-RUN yum update -y \
-  && amazon-linux-extras install postgresql11 \
-  && yum install -y \
+# Make sure this path includes initdb for the usage of tmp-postgres
+ENV PATH=/usr/lib/postgresql/12/bin/$PATH
+
+RUN apt-get update -y \
+  && apt-get install -y \
+    curl \
     gcc \
     git \
-    gmp-devel \
     gzip \
+    libgmp-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libpq-dev \
     make \
-    nc \
-    ncurses-devel \
+    netcat-openbsd \
     perl \
+    postgresql-12 \
     procps \
     sudo \
     tar \
     wget \
-    xz \
-    xz-devel \
+    xz-utils \
     zip \
-    zlib-devel \
-  && yum clean all \
-  && rm -rf /var/cache/yum \
+    zlib1g-dev \
+  && apt-get autoremove \
   && mkdir -p /tmp/stack \
   && cd /tmp/stack \
   && wget --output-document stack.tgz --no-verbose "https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz" \


### PR DESCRIPTION
Story details: https://app.clubhouse.io/itprotv/story/69522

Changes:
- No longer creating haskell user at this level since we only need non-root complexity for developing purposes (tmp-postgres)
- Use ubuntu base image 
  - This is a change we wanted to do
  - We decided on doing it now because amazon's base completely lost postgresql in the current repo and trying to solve that puzzle was not worth the time 